### PR TITLE
Injection on storyboard reference

### DIFF
--- a/Sources/Storyboard+Swizzling.swift
+++ b/Sources/Storyboard+Swizzling.swift
@@ -44,7 +44,11 @@ extension Storyboard {
     private class func swinject_storyboardWithName(name: String, bundle storyboardBundleOrNil: NSBundle) -> Storyboard {
         if self === Storyboard.self {
             // Instantiate SwinjectStoryboard if UI/NSStoryboard is tried to be instantiated.
-            return SwinjectStoryboard.create(name: name, bundle: storyboardBundleOrNil)
+            if SwinjectStoryboard.isCreatingStoryboardReference {
+                return SwinjectStoryboard.createReferenced(name: name, bundle: storyboardBundleOrNil)
+            } else {
+                return SwinjectStoryboard.create(name: name, bundle: storyboardBundleOrNil)
+            }
         } else {
             // Call original `storyboardWithName:bundle:` method swizzled with `swinject_storyboardWithName:bundle:`
             // if SwinjectStoryboard is tried to be instantiated.

--- a/Sources/SwinjectStoryboard+StoryboardReference.swift
+++ b/Sources/SwinjectStoryboard+StoryboardReference.swift
@@ -1,0 +1,36 @@
+//
+//  SwinjectStoryboard+StoryboardReference.
+//  SwinjectStoryboard
+//
+//  Created by Jakub Vaňo on 01/09/16.
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
+//
+
+internal extension SwinjectStoryboard {
+
+    static func pushInstantiatingStoryboard(storyboard: SwinjectStoryboard) {
+        storyboardStack.append(storyboard)
+    }
+
+    static func popInstantiatingStoryboard() -> SwinjectStoryboard? {
+        return storyboardStack.popLast()
+    }
+
+    static var isCreatingStoryboardReference: Bool {
+        return referencingStoryboard != nil
+    }
+
+    static var referencingStoryboard: SwinjectStoryboard? {
+        return storyboardStack.last
+    }
+
+    static func createReferenced(name name: String, bundle storyboardBundleOrNil: NSBundle?) -> SwinjectStoryboard {
+        if let container = referencingStoryboard?.container.value {
+            return create(name: name, bundle: storyboardBundleOrNil, container: container)
+        } else {
+            return create(name: name, bundle: storyboardBundleOrNil)
+        }
+    }
+}
+
+private var storyboardStack = [SwinjectStoryboard]()

--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -32,7 +32,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
     // Boxing to workaround a runtime error [Xcode 7.1.1 and Xcode 7.2 beta 4]
     // If container property is ResolverType type and a ResolverType instance is assigned to the property,
     // the program crashes by EXC_BAD_ACCESS, which looks a bug of Swift.
-    private var container: Box<ResolverType>!
+    internal var container: Box<ResolverType>!
     
     /// Do NOT call this method explicitly. It is designed to be called by the runtime.
     public override class func initialize() {
@@ -78,7 +78,10 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
     ///
     /// - Returns: The instantiated view controller with its dependencies injected.
     public override func instantiateViewControllerWithIdentifier(identifier: String) -> UIViewController {
+        SwinjectStoryboard.pushInstantiatingStoryboard(self)
         let viewController = super.instantiateViewControllerWithIdentifier(identifier)
+        SwinjectStoryboard.popInstantiatingStoryboard()
+
         injectDependency(viewController)
         return viewController
     }

--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -82,7 +82,9 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
         let viewController = super.instantiateViewControllerWithIdentifier(identifier)
         SwinjectStoryboard.popInstantiatingStoryboard()
 
-        injectDependency(viewController)
+        if !SwinjectStoryboard.isCreatingStoryboardReference {
+            injectDependency(viewController)
+        }
         return viewController
     }
     
@@ -118,7 +120,10 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
         let controller = super.instantiateControllerWithIdentifier(identifier)
         SwinjectStoryboard.popInstantiatingStoryboard()
 
-        injectDependency(controller)
+        if !SwinjectStoryboard.isCreatingStoryboardReference {
+            injectDependency(controller)
+        }
+
         return controller
     }
     

--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -114,7 +114,10 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
     ///
     /// - Returns: The instantiated view/window controller with its dependencies injected.
     public override func instantiateControllerWithIdentifier(identifier: String) -> AnyObject {
+        SwinjectStoryboard.pushInstantiatingStoryboard(self)
         let controller = super.instantiateControllerWithIdentifier(identifier)
+        SwinjectStoryboard.popInstantiatingStoryboard()
+
         injectDependency(controller)
         return controller
     }

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -101,6 +101,8 @@
 		CD2C63A21D784F150075BC14 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */; };
 		CD2C63A71D7856210075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */; };
 		CD2C63A81D7856210075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */; };
+		CD2C63AA1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */; };
+		CD2C63AB1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -415,6 +417,7 @@
 		98D563841CDB28CE00DECDC0 /* Quick.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Quick.xcodeproj; path = Carthage/Checkouts/Quick/Quick.xcodeproj; sourceTree = "<group>"; };
 		CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
 		CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference2.storyboard; sourceTree = "<group>"; };
+		CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwinjectStoryboard+StoryboardReference.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -603,6 +606,7 @@
 				983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */,
 				983DFF0A1CDB440800D39731 /* Box.swift */,
 				983DFF0E1CDB444E00D39731 /* RegistrationNameAssociatable.swift */,
+				CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */,
 				985904091CDB0AA700275E4A /* SwinjectStoryboard.h */,
 				9859040B1CDB0AA700275E4A /* Info.plist */,
 			);
@@ -1177,6 +1181,7 @@
 				983DFEAE1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF0F1CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAB1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
+				CD2C63AA1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
 				983DFEB11CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
 				983DFF0B1CDB440800D39731 /* Box.swift in Sources */,
 				983DFEBE1CDB414900D39731 /* _SwinjectStoryboardBase.m in Sources */,
@@ -1244,6 +1249,7 @@
 				983DFEB01CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF111CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAD1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
+				CD2C63AB1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
 				983DFEB31CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
 				983DFF0D1CDB440800D39731 /* Box.swift in Sources */,
 				983DFEBF1CDB414900D39731 /* _SwinjectStoryboardBase.m in Sources */,

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -97,6 +97,10 @@
 		98D563AD1CDB2A2100DECDC0 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D563911CDB28CE00DECDC0 /* Quick.framework */; };
 		98D563B21CDB2A3400DECDC0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D563811CDB28C700DECDC0 /* Nimble.framework */; };
 		98D563B31CDB2A3400DECDC0 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D5639D1CDB28CE00DECDC0 /* Quick.framework */; };
+		CD2C63A11D784F150075BC14 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */; };
+		CD2C63A21D784F150075BC14 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */; };
+		CD2C63A71D7856210075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */; };
+		CD2C63A81D7856210075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -409,6 +413,8 @@
 		98D562CC1CDB1E8800DECDC0 /* tvOS-StaticLibrary.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "tvOS-StaticLibrary.xcconfig"; sourceTree = "<group>"; };
 		98D5636F1CDB28C700DECDC0 /* Nimble.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Nimble.xcodeproj; path = Carthage/Checkouts/Nimble/Nimble.xcodeproj; sourceTree = "<group>"; };
 		98D563841CDB28CE00DECDC0 /* Quick.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Quick.xcodeproj; path = Carthage/Checkouts/Quick/Quick.xcodeproj; sourceTree = "<group>"; };
+		CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
+		CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference2.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -542,6 +548,8 @@
 				983DFEDA1CDB425600D39731 /* Storyboard1.storyboard */,
 				983DFEDB1CDB425600D39731 /* Storyboard2.storyboard */,
 				983DFED71CDB425600D39731 /* AnimalPlayerViewController.swift */,
+				CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */,
+				CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */,
 				983DFED61CDB425600D39731 /* AnimalPlayerViewController.storyboard */,
 			);
 			name = Fakes;
@@ -1108,6 +1116,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD2C63A11D784F150075BC14 /* RelationshipReference1.storyboard in Resources */,
+				CD2C63A71D7856210075BC14 /* RelationshipReference2.storyboard in Resources */,
 				983DFEE81CDB425600D39731 /* Storyboard2.storyboard in Resources */,
 				983DFEE21CDB425600D39731 /* Animals.storyboard in Resources */,
 				983DFEEC1CDB425600D39731 /* Tabs.storyboard in Resources */,
@@ -1145,6 +1155,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD2C63A21D784F150075BC14 /* RelationshipReference1.storyboard in Resources */,
+				CD2C63A81D7856210075BC14 /* RelationshipReference2.storyboard in Resources */,
 				983DFEE91CDB425600D39731 /* Storyboard2.storyboard in Resources */,
 				983DFEE31CDB425600D39731 /* Animals.storyboard in Resources */,
 				983DFEED1CDB425600D39731 /* Tabs.storyboard in Resources */,
@@ -1391,6 +1403,7 @@
 			baseConfigurationReference = 98D562BD1CDB1E8800DECDC0 /* iOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
@@ -1401,6 +1414,7 @@
 			baseConfigurationReference = 98D562BD1CDB1E8800DECDC0 /* iOS-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -103,6 +103,9 @@
 		CD2C63A81D7856210075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */; };
 		CD2C63AA1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */; };
 		CD2C63AB1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */; };
+		CD2C63AD1D786C1F0075BC14 /* RelationshipReference1.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63AC1D786C1F0075BC14 /* RelationshipReference1.storyboard */; };
+		CD2C63AF1D786CD70075BC14 /* RelationshipReference2.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CD2C63AE1D786CD70075BC14 /* RelationshipReference2.storyboard */; };
+		CD2C63B01D786D6B0075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -418,6 +421,8 @@
 		CD2C63A01D784F150075BC14 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
 		CD2C63A61D7856210075BC14 /* RelationshipReference2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference2.storyboard; sourceTree = "<group>"; };
 		CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwinjectStoryboard+StoryboardReference.swift"; sourceTree = "<group>"; };
+		CD2C63AC1D786C1F0075BC14 /* RelationshipReference1.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference1.storyboard; sourceTree = "<group>"; };
+		CD2C63AE1D786CD70075BC14 /* RelationshipReference2.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = RelationshipReference2.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -536,6 +541,8 @@
 				983DFEEF1CDB426100D39731 /* Animals.storyboard */,
 				983DFEF51CDB426100D39731 /* Tabs.storyboard */,
 				983DFEF61CDB426100D39731 /* ViewController1.swift */,
+				CD2C63AC1D786C1F0075BC14 /* RelationshipReference1.storyboard */,
+				CD2C63AE1D786CD70075BC14 /* RelationshipReference2.storyboard */,
 				983DFEF21CDB426100D39731 /* Storyboard1.storyboard */,
 				983DFEF31CDB426100D39731 /* Storyboard2.storyboard */,
 			);
@@ -1145,6 +1152,8 @@
 				983DFEF71CDB426100D39731 /* Animals.storyboard in Resources */,
 				983DFEFB1CDB426100D39731 /* Storyboard2.storyboard in Resources */,
 				983DFEFA1CDB426100D39731 /* Storyboard1.storyboard in Resources */,
+				CD2C63AD1D786C1F0075BC14 /* RelationshipReference1.storyboard in Resources */,
+				CD2C63AF1D786CD70075BC14 /* RelationshipReference2.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1214,6 +1223,7 @@
 				983DFEA61CDB410D00D39731 /* Container+SwinjectStoryboard.swift in Sources */,
 				983DFEAF1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF101CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
+				CD2C63B01D786D6B0075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
 				983DFEAC1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
 				983DFEB21CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
 				983DFF0C1CDB440800D39731 /* Box.swift in Sources */,
@@ -1460,6 +1470,7 @@
 			baseConfigurationReference = 98D562C21CDB1E8800DECDC0 /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
@@ -1470,6 +1481,7 @@
 			baseConfigurationReference = 98D562C21CDB1E8800DECDC0 /* Mac-Application.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};

--- a/Tests/OSX/RelationshipReference1.storyboard
+++ b/Tests/OSX/RelationshipReference1.storyboard
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LlO-qX-Ly8">
+    <dependencies>
+        <deployment version="101100" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="G1l-FP-akj">
+            <objects>
+                <windowController id="LlO-qX-Ly8" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="E1A-bX-waF">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="294" y="313" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
+                    </window>
+                    <connections>
+                        <segue destination="wPZ-dc-sqo" kind="relationship" relationship="window.shadowedContentViewController" id="08X-ON-IRg"/>
+                    </connections>
+                </windowController>
+                <customObject id="90K-aN-M7k" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="598" y="512"/>
+        </scene>
+        <!--RelationshipReference2-->
+        <scene sceneID="ToZ-Ha-Pau">
+            <objects>
+                <controllerPlaceholder storyboardName="RelationshipReference2" id="wPZ-dc-sqo" sceneMemberID="viewController"/>
+                <customObject id="SKV-Le-wm6" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1105.5" y="505"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/OSX/RelationshipReference2.storyboard
+++ b/Tests/OSX/RelationshipReference2.storyboard
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="ISX-5c-PWr">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10117"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller1-->
+        <scene sceneID="zBi-S5-Jl2">
+            <objects>
+                <viewController id="ISX-5c-PWr" customClass="ViewController1" customModule="SwinjectStoryboardTests" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="fIJ-nS-YnZ">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                    <connections>
+                        <segue destination="jDD-Ae-2DW" kind="show" identifier="ToAnimalViewController" id="g7Y-J9-W2Z"/>
+                    </connections>
+                </viewController>
+                <customObject id="BBQ-xh-hoQ" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="331" y="443"/>
+        </scene>
+        <!--Animal View Controller-->
+        <scene sceneID="UYy-7L-Qmw">
+            <objects>
+                <viewController id="jDD-Ae-2DW" customClass="AnimalViewController" customModule="SwinjectStoryboardTests" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="hVz-BN-z29">
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </view>
+                </viewController>
+                <customObject id="2fQ-nW-MQl" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="912" y="443"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/OSX/SwinjectStoryboardSpec.swift
+++ b/Tests/OSX/SwinjectStoryboardSpec.swift
@@ -148,6 +148,21 @@ class SwinjectStoryboardSpec: QuickSpec {
                 viewController1.performSegueWithIdentifier("ToStoryboard2", sender: nil)
                 expect(viewController1.animalViewController?.hasAnimal(named: "Mimi")).toEventually(beTrue())
             }
+            context("not using defaultContainer and referencing storyboard via relationship segue") {
+                it("injects dependency to the view controller opened via segue") {
+                    container.registerForStoryboard(AnimalViewController.self) { r, c in
+                        c.animal = r.resolve(AnimalType.self)
+                    }
+                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+
+                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
+                    let windowController = storyboard.instantiateInitialController() as! NSWindowController
+                    let viewController1 = windowController.contentViewController as! ViewController1
+                    viewController1.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
+
+                    expect(viewController1.animalViewController?.hasAnimal(named: "Mimi")).toEventually(beTrue())
+                }
+            }
             
             afterEach {
                 SwinjectStoryboard.defaultContainer.removeAll()

--- a/Tests/OSX/SwinjectStoryboardSpec.swift
+++ b/Tests/OSX/SwinjectStoryboardSpec.swift
@@ -148,19 +148,32 @@ class SwinjectStoryboardSpec: QuickSpec {
                 viewController1.performSegueWithIdentifier("ToStoryboard2", sender: nil)
                 expect(viewController1.animalViewController?.hasAnimal(named: "Mimi")).toEventually(beTrue())
             }
-            context("not using defaultContainer and referencing storyboard via relationship segue") {
-                it("injects dependency to the view controller opened via segue") {
-                    container.registerForStoryboard(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+            context("referencing storyboard via relationship segue") {
+                it("should inject dependencies once") {
+                    var injectedTimes = 0
+                    SwinjectStoryboard.defaultContainer.registerForStoryboard(ViewController1.self) { r, c in
+                        injectedTimes += 1
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
 
-                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
-                    let windowController = storyboard.instantiateInitialController() as! NSWindowController
-                    let viewController1 = windowController.contentViewController as! ViewController1
-                    viewController1.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
+                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle)
+                    storyboard.instantiateInitialController()
 
-                    expect(viewController1.animalViewController?.hasAnimal(named: "Mimi")).toEventually(beTrue())
+                    expect(injectedTimes) == 1
+                }
+                context("not using default container") {
+                    it("injects dependency to the view controller opened via segue") {
+                        container.registerForStoryboard(AnimalViewController.self) { r, c in
+                            c.animal = r.resolve(AnimalType.self)
+                        }
+                        container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+
+                        let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
+                        let windowController = storyboard.instantiateInitialController() as! NSWindowController
+                        let viewController1 = windowController.contentViewController as! ViewController1
+                        viewController1.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
+
+                        expect(viewController1.animalViewController?.hasAnimal(named: "Mimi")).toEventually(beTrue())
+                    }
                 }
             }
             

--- a/Tests/iOS-tvOS/RelationshipReference1.storyboard
+++ b/Tests/iOS-tvOS/RelationshipReference1.storyboard
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="9wn-4E-eDB">
+    <dependencies>
+        <deployment version="2304" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--Navigation Controller-->
+        <scene sceneID="pbb-1O-FwV">
+            <objects>
+                <navigationController id="9wn-4E-eDB" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Bj1-6C-pL8">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="2nj-0X-aHf" kind="relationship" relationship="rootViewController" id="rHA-Gw-idy"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="YEu-8d-zlg" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-365" y="200"/>
+        </scene>
+        <!--RelationshipReference2-->
+        <scene sceneID="KOs-Et-lNp">
+            <objects>
+                <viewControllerPlaceholder storyboardName="RelationshipReference2" id="2nj-0X-aHf" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="4zL-dt-2wW"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qbA-xs-flb" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="184.5" y="200"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/iOS-tvOS/RelationshipReference2.storyboard
+++ b/Tests/iOS-tvOS/RelationshipReference2.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="Jmi-bh-bca">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="RLu-Vk-zeS">
+            <objects>
+                <viewController id="Jmi-bh-bca" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="QBb-dZ-5Yh"/>
+                        <viewControllerLayoutGuide type="bottom" id="ivB-O3-Ys6"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="0xE-Gc-kHM">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                    <connections>
+                        <segue destination="Dk1-st-y72" kind="show" identifier="ToAnimalViewController" animates="NO" id="NQH-H6-XLo"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="WcN-sb-t2L" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1521" y="237"/>
+        </scene>
+        <!--Animal View Controller-->
+        <scene sceneID="opP-M2-8Tz">
+            <objects>
+                <viewController id="Dk1-st-y72" customClass="AnimalViewController" customModule="SwinjectStoryboardTests" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ozc-pg-BET"/>
+                        <viewControllerLayoutGuide type="bottom" id="KTB-ft-H3k"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="vOL-Q0-Ucv">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Sk4-Ms-R4m" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-825" y="237"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
+++ b/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
@@ -134,19 +134,32 @@ class SwinjectStoryboardSpec: QuickSpec {
                 let animalViewController = navigationController.topViewController as! AnimalViewController
                 expect(animalViewController.hasAnimal(named: "Mimi")) == true
             }
-            context("not using defaultContainer and referencing storyboard via relationship segue") {
-                it("injects dependency to the view controller opened via segue") {
-                    container.registerForStoryboard(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+            context("referencing storyboard via relationship segue") {
+                it("should inject dependencies once") {
+                    var injectedTimes = 0
+                    SwinjectStoryboard.defaultContainer.registerForStoryboard(UIViewController.self) { r, c in
+                        injectedTimes += 1
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
 
-                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
-                    let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
-                    navigationController.topViewController!.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
-                    let animalViewController = navigationController.topViewController as! AnimalViewController
+                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle)
+                    storyboard.instantiateInitialViewController()
 
-                    expect(animalViewController.hasAnimal(named: "Mimi")) == true
+                    expect(injectedTimes) == 1
+                }
+                context("not using defaultContainer") {
+                    it("injects dependency to the view controller opened via segue") {
+                        container.registerForStoryboard(AnimalViewController.self) { r, c in
+                            c.animal = r.resolve(AnimalType.self)
+                        }
+                        container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+
+                        let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
+                        let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
+                        navigationController.topViewController!.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
+                        let animalViewController = navigationController.topViewController as! AnimalViewController
+
+                        expect(animalViewController.hasAnimal(named: "Mimi")) == true
+                    }
                 }
             }
             

--- a/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
+++ b/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
@@ -121,50 +121,55 @@ class SwinjectStoryboardSpec: QuickSpec {
                 SwinjectStoryboard.defaultContainer.removeAll()
             }
         }
-        describe("Storyboard reference") {
-            it("inject dependency to the view controller in the referenced storyboard.") {
-                SwinjectStoryboard.defaultContainer.registerForStoryboard(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
-                }
-                SwinjectStoryboard.defaultContainer.register(AnimalType.self) { _ in Cat(name: "Mimi") }
-                
-                let storyboard1 = SwinjectStoryboard.create(name: "Storyboard1", bundle: bundle)
-                let navigationController = storyboard1.instantiateInitialViewController() as! UINavigationController
-                navigationController.performSegueWithIdentifier("ToStoryboard2", sender: navigationController)
-                let animalViewController = navigationController.topViewController as! AnimalViewController
-                expect(animalViewController.hasAnimal(named: "Mimi")) == true
-            }
-            context("referencing storyboard via relationship segue") {
-                it("should inject dependencies once") {
-                    var injectedTimes = 0
-                    SwinjectStoryboard.defaultContainer.registerForStoryboard(UIViewController.self) { r, c in
-                        injectedTimes += 1
+        // We need to have test bundle deployment target on iOS 9.0 in order to compile storyboards with references.
+        // However, we need to disable these tests when running on iOS <9.0
+        // Using #available(iOS 9.0, *) produces complier warning for the reasons above
+        if NSProcessInfo().isOperatingSystemAtLeastVersion(NSOperatingSystemVersion(majorVersion: 9, minorVersion: 0, patchVersion: 0)) {
+            describe("Storyboard reference") {
+                it("inject dependency to the view controller in the referenced storyboard.") {
+                    SwinjectStoryboard.defaultContainer.registerForStoryboard(AnimalViewController.self) { r, c in
+                        c.animal = r.resolve(AnimalType.self)
                     }
+                    SwinjectStoryboard.defaultContainer.register(AnimalType.self) { _ in Cat(name: "Mimi") }
 
-                    let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle)
-                    storyboard.instantiateInitialViewController()
-
-                    expect(injectedTimes) == 1
+                    let storyboard1 = SwinjectStoryboard.create(name: "Storyboard1", bundle: bundle)
+                    let navigationController = storyboard1.instantiateInitialViewController() as! UINavigationController
+                    navigationController.performSegueWithIdentifier("ToStoryboard2", sender: navigationController)
+                    let animalViewController = navigationController.topViewController as! AnimalViewController
+                    expect(animalViewController.hasAnimal(named: "Mimi")) == true
                 }
-                context("not using defaultContainer") {
-                    it("injects dependency to the view controller opened via segue") {
-                        container.registerForStoryboard(AnimalViewController.self) { r, c in
-                            c.animal = r.resolve(AnimalType.self)
+                context("referencing storyboard via relationship segue") {
+                    it("should inject dependencies once") {
+                        var injectedTimes = 0
+                        SwinjectStoryboard.defaultContainer.registerForStoryboard(UIViewController.self) { r, c in
+                            injectedTimes += 1
                         }
-                        container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
 
-                        let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
-                        let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
-                        navigationController.topViewController!.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
-                        let animalViewController = navigationController.topViewController as! AnimalViewController
+                        let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle)
+                        storyboard.instantiateInitialViewController()
 
-                        expect(animalViewController.hasAnimal(named: "Mimi")) == true
+                        expect(injectedTimes) == 1
+                    }
+                    context("not using defaultContainer") {
+                        it("injects dependency to the view controller opened via segue") {
+                            container.registerForStoryboard(AnimalViewController.self) { r, c in
+                                c.animal = r.resolve(AnimalType.self)
+                            }
+                            container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+
+                            let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
+                            let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController
+                            navigationController.topViewController!.performSegueWithIdentifier("ToAnimalViewController", sender: nil)
+                            let animalViewController = navigationController.topViewController as! AnimalViewController
+
+                            expect(animalViewController.hasAnimal(named: "Mimi")) == true
+                        }
                     }
                 }
-            }
-            
-            afterEach {
-                SwinjectStoryboard.defaultContainer.removeAll()
+                
+                afterEach {
+                    SwinjectStoryboard.defaultContainer.removeAll()
+                }
             }
         }
         describe("Setup") {


### PR DESCRIPTION
As reported in [Swinject#128](https://github.com/Swinject/Swinject/issues/128), injection on storyboard references does not work properly when initial storyboard is created with custom (other than `defaultContainer`) container. @VladimirBorodko pointed out in [this comment](https://github.com/Swinject/Swinject/issues/128#issuecomment-239968060) that problem is caused by not passing custom container when creating an instance of referenced storyboard.

This fixes the issue, however it introduces stack of storyboards used during instantiation of view controller, which is needed to obtain container of "parent" storyboard when creating storyboard reference. It is a bit too hacky for my taste, and would love if someone could come up with better solution.