### PR TITLE
Update Swinject version

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.0.0-beta.2"
+github "Swinject/Swinject" "c088d36d3b6082cd07176c19f3e1e9518b240c8c"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Quick/Nimble" "220152be528dcc0537764c179c95b8174028c80c"
 github "Quick/Quick" "81d2a7bd95ef91e2604ee0431bba6fe59ad662dc"
-github "Swinject/Swinject" "2.0.0-beta.2"
+github "Swinject/Swinject" "c088d36d3b6082cd07176c19f3e1e9518b240c8c"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"


### PR DESCRIPTION
Update Swinject to use the version where ResolverType is renamed to Resolver to get #24 effective.