### PR TITLE
Renamed protocols for Swift 3 conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Here is a simple example to register a dependency of a view controller without a
 ```swift
 let container = Container()
 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-    c.animal = r.resolve(AnimalType.self)
+    c.animal = r.resolve(Animal.self)
 }
-container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+container.register(Animal.self) { _ in Cat(name: "Mimi") }
 ```
 
 Next, we create an instance of `SwinjectStoryboard` with the container specified. If the container is not specified, `SwinjectStoryboard.defaultContainer` is used instead. `instantiateViewControllerWithIdentifier` method creates an instance of the view controller with its dependencies injected:
@@ -80,18 +80,18 @@ Where the classes and protocol are:
 
 ```swift
 class AnimalViewController: UIViewController {
-    var animal: AnimalType?
+    var animal: Animal?
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 }
 
-protocol AnimalType {
+protocol Animal {
     var name: String { get set }
 }
 
-class Cat: AnimalType {
+class Cat: Animal {
     var name: String
 
     init(name: String) {
@@ -111,15 +111,15 @@ If a storyboard has more than one view controller with the same type, dependenci
 ```swift
 let container = Container()
 container.storyboardInitCompleted(AnimalViewController.self, name: "cat") {
-    r, c in c.animal = r.resolve(AnimalType.self, name: "mimi")
+    r, c in c.animal = r.resolve(Animal.self, name: "mimi")
 }
 container.storyboardInitCompleted(AnimalViewController.self, name: "dog") {
-    r, c in c.animal = r.resolve(AnimalType.self, name: "hachi")
+    r, c in c.animal = r.resolve(Animal.self, name: "hachi")
 }
-container.register(AnimalType.self, name: "mimi") {
+container.register(Animal.self, name: "mimi") {
     _ in Cat(name: "Mimi")
 }
-container.register(AnimalType.self, name: "hachi") {
+container.register(Animal.self, name: "hachi") {
     _ in Dog(name: "Hachi")
 }
 ```
@@ -140,7 +140,7 @@ print(dogController.animal!.name) // prints "Hachi"
 Where `Dog` class is:
 
 ```swift
-class Dog: AnimalType {
+class Dog: Animal {
     var name: String
 
     init(name: String) {
@@ -163,9 +163,9 @@ If you implicitly instantiate `UIWindow` and its root view controller from "Main
 extension SwinjectStoryboard {
     class func setup() {
         defaultContainer.storyboardInitCompleted(AnimalViewController.self) { r, c in
-            c.animal = r.resolve(AnimalType.self)
+            c.animal = r.resolve(Animal.self)
         }
-        defaultContainer.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+        defaultContainer.register(Animal.self) { _ in Cat(name: "Mimi") }
     }
 }
 ```
@@ -181,16 +181,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var container: Container = {
         let container = Container()
         container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-            c.animal = r.resolve(AnimalType.self)
+            c.animal = r.resolve(Animal.self)
         }
-        container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+        container.register(Animal.self) { _ in Cat(name: "Mimi") }
         return container
     }()
 
     func application(
-        application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool
-    {
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+
         let window = UIWindow(frame: UIScreen.mainScreen().bounds)
         window.makeKeyAndVisible()
         self.window = window
@@ -212,9 +212,9 @@ Storyboard Reference introduced with Xcode 7 is supported by `SwinjectStoryboard
 ```swift
 let container = SwinjectStoryboard.defaultContainer
 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-    c.animal = r.resolve(AnimalType.self)
+    c.animal = r.resolve(Animal.self)
 }
-container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+container.register(Animal.self) { _ in Cat(name: "Mimi") }
 ```
 
 If you implicitly instantiate `UIWindow` and its root view controller, the registrations setup for "Main" storyboard can be shared with the referenced storyboard since `defaultContainer` is configured in `setup` method.

--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -21,7 +21,7 @@ import Swinject
 ///
 /// in User Defined Runtime Attributes section on Indentity Inspector pane.
 /// If no name is supplied to the registration, no runtime attribute should be specified.
-public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType {
+public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardProtocol {
     /// A shared container used by SwinjectStoryboard instances that are instantiated without specific containers.
     ///
     /// Typical usecases of this property are:
@@ -38,7 +38,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardType
     public override class func initialize() {
         struct Static {
             static var onceToken: () = {
-                (SwinjectStoryboard.self as SwinjectStoryboardType.Type).setup?()
+                (SwinjectStoryboard.self as SwinjectStoryboardProtocol.Type).setup?()
             }()
         }
         let _ = Static.onceToken

--- a/Sources/SwinjectStoryboardProtocol.swift
+++ b/Sources/SwinjectStoryboardProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  SwinjectStoryboardType.swift
+//  SwinjectStoryboardProtocol.swift
 //  Swinject
 //
 //  Created by Yoichi Tagaya on 10/12/15.
@@ -12,7 +12,7 @@
 // default implementation of a protocol method is always called if a class method conforming the protocol
 // is defined as an extention in a different framework.
 @objc
-public protocol SwinjectStoryboardType {
+public protocol SwinjectStoryboardProtocol {
     /// Called by Swinject framework once before SwinjectStoryboard is instantiated.
     ///
     /// - Note:

--- a/Sources/UnavailableItems.swift
+++ b/Sources/UnavailableItems.swift
@@ -1,0 +1,11 @@
+//
+//  UnavailableItems.swift
+//  SwinjectStoryboard
+//
+//  Created by Yoichi Tagaya on 12/10/16.
+//  Copyright © 2016 Swinject Contributors. All rights reserved.
+//
+
+// MARK: For auto migration to Swinject v1.
+@available(*, unavailable, renamed: "SwinjectStoryboardProtocol")
+public protocol SwinjectStoryboardType { }

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -22,9 +22,9 @@
 		983DFEAE1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA21CDB410D00D39731 /* SwinjectStoryboardOption.swift */; };
 		983DFEAF1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA21CDB410D00D39731 /* SwinjectStoryboardOption.swift */; };
 		983DFEB01CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA21CDB410D00D39731 /* SwinjectStoryboardOption.swift */; };
-		983DFEB11CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardType.swift */; };
-		983DFEB21CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardType.swift */; };
-		983DFEB31CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardType.swift */; };
+		983DFEB11CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift */; };
+		983DFEB21CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift */; };
+		983DFEB31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift */; };
 		983DFEB41CDB410D00D39731 /* ViewController+Swinject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */; };
 		983DFEB51CDB410D00D39731 /* ViewController+Swinject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */; };
 		983DFEB61CDB410D00D39731 /* ViewController+Swinject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */; };
@@ -89,6 +89,9 @@
 		9859040A1CDB0AA700275E4A /* SwinjectStoryboard.h in Headers */ = {isa = PBXBuildFile; fileRef = 985904091CDB0AA700275E4A /* SwinjectStoryboard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		985904111CDB0AA700275E4A /* SwinjectStoryboard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 985904061CDB0AA700275E4A /* SwinjectStoryboard.framework */; };
 		985904161CDB0AA700275E4A /* SwinjectStoryboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985904151CDB0AA700275E4A /* SwinjectStoryboardTests.swift */; };
+		98978E681DFC354B0046B966 /* UnavailableItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98978E671DFC354B0046B966 /* UnavailableItems.swift */; };
+		98978E691DFC354B0046B966 /* UnavailableItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98978E671DFC354B0046B966 /* UnavailableItems.swift */; };
+		98978E6A1DFC354B0046B966 /* UnavailableItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98978E671DFC354B0046B966 /* UnavailableItems.swift */; };
 		98D562821CDB173500DECDC0 /* SwinjectStoryboard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D562781CDB173500DECDC0 /* SwinjectStoryboard.framework */; };
 		98D5629E1CDB19AB00DECDC0 /* SwinjectStoryboard.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D562941CDB19AB00DECDC0 /* SwinjectStoryboard.framework */; };
 		98D563A61CDB29FA00DECDC0 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98D563791CDB28C700DECDC0 /* Nimble.framework */; };
@@ -201,6 +204,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = 985904051CDB0AA700275E4A;
 			remoteInfo = SwinjectStoryboard;
+		};
+		98978E5B1DFC34500046B966 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 98D563841CDB28CE00DECDC0 /* Quick.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 64076CF51D6D7C2000E2B499;
+			remoteInfo = "QuickAfterSuite-macOSTests";
+		};
+		98978E5D1DFC34500046B966 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 98D563841CDB28CE00DECDC0 /* Quick.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 64076D081D6D7CD600E2B499;
+			remoteInfo = "QuickAfterSuite-iOSTests";
+		};
+		98978E5F1DFC34500046B966 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 98D563841CDB28CE00DECDC0 /* Quick.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 64076D1A1D6D7CEA00E2B499;
+			remoteInfo = "QuickAfterSuite-tvOSTests";
 		};
 		98D562831CDB173500DECDC0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -364,7 +388,7 @@
 		983DFEA01CDB410D00D39731 /* Storyboard+Swizzling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Storyboard+Swizzling.swift"; sourceTree = "<group>"; };
 		983DFEA11CDB410D00D39731 /* SwinjectStoryboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboard.swift; sourceTree = "<group>"; };
 		983DFEA21CDB410D00D39731 /* SwinjectStoryboardOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardOption.swift; sourceTree = "<group>"; };
-		983DFEA31CDB410D00D39731 /* SwinjectStoryboardType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardType.swift; sourceTree = "<group>"; };
+		983DFEA31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardProtocol.swift; sourceTree = "<group>"; };
 		983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ViewController+Swinject.swift"; sourceTree = "<group>"; };
 		983DFEBA1CDB414900D39731 /* _SwinjectStoryboardBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = _SwinjectStoryboardBase.h; sourceTree = "<group>"; };
 		983DFEBB1CDB414900D39731 /* _SwinjectStoryboardBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = _SwinjectStoryboardBase.m; sourceTree = "<group>"; };
@@ -400,6 +424,7 @@
 		985904101CDB0AA700275E4A /* SwinjectStoryboardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwinjectStoryboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		985904151CDB0AA700275E4A /* SwinjectStoryboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardTests.swift; sourceTree = "<group>"; };
 		985904171CDB0AA700275E4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		98978E671DFC354B0046B966 /* UnavailableItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnavailableItems.swift; sourceTree = "<group>"; };
 		98D562781CDB173500DECDC0 /* SwinjectStoryboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwinjectStoryboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D562811CDB173500DECDC0 /* SwinjectStoryboardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwinjectStoryboardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D562941CDB19AB00DECDC0 /* SwinjectStoryboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwinjectStoryboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -625,7 +650,7 @@
 				983DFEC01CDB415300D39731 /* OSX */,
 				983DFE9F1CDB410D00D39731 /* Container+SwinjectStoryboard.swift */,
 				983DFEA21CDB410D00D39731 /* SwinjectStoryboardOption.swift */,
-				983DFEA31CDB410D00D39731 /* SwinjectStoryboardType.swift */,
+				983DFEA31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift */,
 				983DFEA11CDB410D00D39731 /* SwinjectStoryboard.swift */,
 				983DFEA01CDB410D00D39731 /* Storyboard+Swizzling.swift */,
 				983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */,
@@ -633,6 +658,7 @@
 				CD3AB1B11DC3A94A001A45FA /* InjectionVerifiable.swift */,
 				983DFF0E1CDB444E00D39731 /* RegistrationNameAssociatable.swift */,
 				CD2C63A91D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift */,
+				98978E671DFC354B0046B966 /* UnavailableItems.swift */,
 				985904091CDB0AA700275E4A /* SwinjectStoryboard.h */,
 				9859040B1CDB0AA700275E4A /* Info.plist */,
 			);
@@ -749,14 +775,17 @@
 			isa = PBXGroup;
 			children = (
 				98D563911CDB28CE00DECDC0 /* Quick.framework */,
-				98D563931CDB28CE00DECDC0 /* Quick-OSXTests.xctest */,
-				98D563951CDB28CE00DECDC0 /* QuickFocused-OSXTests.xctest */,
+				98D563931CDB28CE00DECDC0 /* Quick-macOSTests.xctest */,
+				98D563951CDB28CE00DECDC0 /* QuickFocused-macOSTests.xctest */,
+				98978E5C1DFC34500046B966 /* QuickAfterSuite-macOSTests.xctest */,
 				98D563971CDB28CE00DECDC0 /* Quick.framework */,
 				98D563991CDB28CE00DECDC0 /* Quick-iOSTests.xctest */,
 				98D5639B1CDB28CE00DECDC0 /* QuickFocused-iOSTests.xctest */,
+				98978E5E1DFC34500046B966 /* QuickAfterSuite-iOSTests.xctest */,
 				98D5639D1CDB28CE00DECDC0 /* Quick.framework */,
 				98D5639F1CDB28CE00DECDC0 /* Quick-tvOSTests.xctest */,
 				98D563A11CDB28CE00DECDC0 /* QuickFocused-tvOSTests.xctest */,
+				98978E601DFC34500046B966 /* QuickAfterSuite-tvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1031,6 +1060,27 @@
 			remoteRef = 983DFE6F1CDB38F000D39731 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		98978E5C1DFC34500046B966 /* QuickAfterSuite-macOSTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "QuickAfterSuite-macOSTests.xctest";
+			remoteRef = 98978E5B1DFC34500046B966 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		98978E5E1DFC34500046B966 /* QuickAfterSuite-iOSTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "QuickAfterSuite-iOSTests.xctest";
+			remoteRef = 98978E5D1DFC34500046B966 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		98978E601DFC34500046B966 /* QuickAfterSuite-tvOSTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = "QuickAfterSuite-tvOSTests.xctest";
+			remoteRef = 98978E5F1DFC34500046B966 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		98D563791CDB28C700DECDC0 /* Nimble.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -1080,17 +1130,17 @@
 			remoteRef = 98D563901CDB28CE00DECDC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98D563931CDB28CE00DECDC0 /* Quick-OSXTests.xctest */ = {
+		98D563931CDB28CE00DECDC0 /* Quick-macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "Quick-OSXTests.xctest";
+			path = "Quick-macOSTests.xctest";
 			remoteRef = 98D563921CDB28CE00DECDC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		98D563951CDB28CE00DECDC0 /* QuickFocused-OSXTests.xctest */ = {
+		98D563951CDB28CE00DECDC0 /* QuickFocused-macOSTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = "QuickFocused-OSXTests.xctest";
+			path = "QuickFocused-macOSTests.xctest";
 			remoteRef = 98D563941CDB28CE00DECDC0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -1214,11 +1264,12 @@
 				983DFEA81CDB410D00D39731 /* Storyboard+Swizzling.swift in Sources */,
 				983DFEA51CDB410D00D39731 /* Container+SwinjectStoryboard.swift in Sources */,
 				CD3AB1B21DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
+				98978E681DFC354B0046B966 /* UnavailableItems.swift in Sources */,
 				983DFEAE1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF0F1CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAB1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
 				CD2C63AA1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
-				983DFEB11CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
+				983DFEB11CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */,
 				983DFF0B1CDB440800D39731 /* Box.swift in Sources */,
 				983DFEBE1CDB414900D39731 /* _SwinjectStoryboardBase.m in Sources */,
 				983DFEB41CDB410D00D39731 /* ViewController+Swinject.swift in Sources */,
@@ -1250,11 +1301,12 @@
 				983DFEA91CDB410D00D39731 /* Storyboard+Swizzling.swift in Sources */,
 				983DFEA61CDB410D00D39731 /* Container+SwinjectStoryboard.swift in Sources */,
 				CD3AB1B31DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
+				98978E691DFC354B0046B966 /* UnavailableItems.swift in Sources */,
 				983DFEAF1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF101CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				CD2C63B01D786D6B0075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
 				983DFEAC1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
-				983DFEB21CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
+				983DFEB21CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */,
 				983DFF0C1CDB440800D39731 /* Box.swift in Sources */,
 				983DFEC41CDB415300D39731 /* _SwinjectStoryboardBase.m in Sources */,
 				983DFEB51CDB410D00D39731 /* ViewController+Swinject.swift in Sources */,
@@ -1287,11 +1339,12 @@
 				983DFEAA1CDB410D00D39731 /* Storyboard+Swizzling.swift in Sources */,
 				983DFEA71CDB410D00D39731 /* Container+SwinjectStoryboard.swift in Sources */,
 				CD3AB1B41DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
+				98978E6A1DFC354B0046B966 /* UnavailableItems.swift in Sources */,
 				983DFEB01CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF111CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAD1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
 				CD2C63AB1D7864840075BC14 /* SwinjectStoryboard+StoryboardReference.swift in Sources */,
-				983DFEB31CDB410D00D39731 /* SwinjectStoryboardType.swift in Sources */,
+				983DFEB31CDB410D00D39731 /* SwinjectStoryboardProtocol.swift in Sources */,
 				983DFF0D1CDB440800D39731 /* Box.swift in Sources */,
 				983DFEBF1CDB414900D39731 /* _SwinjectStoryboardBase.m in Sources */,
 				983DFEB61CDB410D00D39731 /* ViewController+Swinject.swift in Sources */,

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -70,12 +70,12 @@
 		983DFEFC1CDB426100D39731 /* SwinjectStoryboardSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEF41CDB426100D39731 /* SwinjectStoryboardSpec.swift */; };
 		983DFEFD1CDB426100D39731 /* Tabs.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 983DFEF51CDB426100D39731 /* Tabs.storyboard */; };
 		983DFEFE1CDB426100D39731 /* ViewController1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFEF61CDB426100D39731 /* ViewController1.swift */; };
-		983DFF041CDB433A00D39731 /* AnimalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* AnimalType.swift */; };
-		983DFF051CDB433A00D39731 /* AnimalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* AnimalType.swift */; };
-		983DFF061CDB433A00D39731 /* AnimalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* AnimalType.swift */; };
-		983DFF071CDB433A00D39731 /* FoodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* FoodType.swift */; };
-		983DFF081CDB433A00D39731 /* FoodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* FoodType.swift */; };
-		983DFF091CDB433A00D39731 /* FoodType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* FoodType.swift */; };
+		983DFF041CDB433A00D39731 /* Animal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* Animal.swift */; };
+		983DFF051CDB433A00D39731 /* Animal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* Animal.swift */; };
+		983DFF061CDB433A00D39731 /* Animal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF021CDB433A00D39731 /* Animal.swift */; };
+		983DFF071CDB433A00D39731 /* Food.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* Food.swift */; };
+		983DFF081CDB433A00D39731 /* Food.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* Food.swift */; };
+		983DFF091CDB433A00D39731 /* Food.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF031CDB433A00D39731 /* Food.swift */; };
 		983DFF0B1CDB440800D39731 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF0A1CDB440800D39731 /* Box.swift */; };
 		983DFF0C1CDB440800D39731 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF0A1CDB440800D39731 /* Box.swift */; };
 		983DFF0D1CDB440800D39731 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DFF0A1CDB440800D39731 /* Box.swift */; };
@@ -414,8 +414,8 @@
 		983DFEF41CDB426100D39731 /* SwinjectStoryboardSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwinjectStoryboardSpec.swift; sourceTree = "<group>"; };
 		983DFEF51CDB426100D39731 /* Tabs.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Tabs.storyboard; sourceTree = "<group>"; };
 		983DFEF61CDB426100D39731 /* ViewController1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController1.swift; sourceTree = "<group>"; };
-		983DFF021CDB433A00D39731 /* AnimalType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnimalType.swift; sourceTree = "<group>"; };
-		983DFF031CDB433A00D39731 /* FoodType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoodType.swift; sourceTree = "<group>"; };
+		983DFF021CDB433A00D39731 /* Animal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Animal.swift; sourceTree = "<group>"; };
+		983DFF031CDB433A00D39731 /* Food.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Food.swift; sourceTree = "<group>"; };
 		983DFF0A1CDB440800D39731 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		983DFF0E1CDB444E00D39731 /* RegistrationNameAssociatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegistrationNameAssociatable.swift; sourceTree = "<group>"; };
 		985904061CDB0AA700275E4A /* SwinjectStoryboard.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwinjectStoryboard.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -611,8 +611,8 @@
 		983DFF011CDB432E00D39731 /* Fakes */ = {
 			isa = PBXGroup;
 			children = (
-				983DFF021CDB433A00D39731 /* AnimalType.swift */,
-				983DFF031CDB433A00D39731 /* FoodType.swift */,
+				983DFF021CDB433A00D39731 /* Animal.swift */,
+				983DFF031CDB433A00D39731 /* Food.swift */,
 			);
 			name = Fakes;
 			sourceTree = "<group>";
@@ -1286,11 +1286,11 @@
 				983DFEEA1CDB425600D39731 /* SwinjectStoryboardSpec.swift in Sources */,
 				983DFEC91CDB423800D39731 /* Container+SwinjectStoryboardSpec.swift in Sources */,
 				983DFECF1CDB423800D39731 /* Storyboard+SwizzlingSpec.swift in Sources */,
-				983DFF071CDB433A00D39731 /* FoodType.swift in Sources */,
+				983DFF071CDB433A00D39731 /* Food.swift in Sources */,
 				983DFECC1CDB423800D39731 /* NSWindowController+SwinjectSpec.swift in Sources */,
 				983DFEE01CDB425600D39731 /* AnimalPlayerViewController.swift in Sources */,
 				985904161CDB0AA700275E4A /* SwinjectStoryboardTests.swift in Sources */,
-				983DFF041CDB433A00D39731 /* AnimalType.swift in Sources */,
+				983DFF041CDB433A00D39731 /* Animal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1320,8 +1320,8 @@
 				983DFEFE1CDB426100D39731 /* ViewController1.swift in Sources */,
 				983DFED31CDB423800D39731 /* ViewController+SwinjectSpec.swift in Sources */,
 				983DFECA1CDB423800D39731 /* Container+SwinjectStoryboardSpec.swift in Sources */,
-				983DFF051CDB433A00D39731 /* AnimalType.swift in Sources */,
-				983DFF081CDB433A00D39731 /* FoodType.swift in Sources */,
+				983DFF051CDB433A00D39731 /* Animal.swift in Sources */,
+				983DFF081CDB433A00D39731 /* Food.swift in Sources */,
 				983DFEFC1CDB426100D39731 /* SwinjectStoryboardSpec.swift in Sources */,
 				983DFED01CDB423800D39731 /* Storyboard+SwizzlingSpec.swift in Sources */,
 				CD3AB1AE1DC3A8CD001A45FA /* AnimalPagesViewController.swift in Sources */,
@@ -1361,11 +1361,11 @@
 				983DFEEB1CDB425600D39731 /* SwinjectStoryboardSpec.swift in Sources */,
 				983DFECB1CDB423800D39731 /* Container+SwinjectStoryboardSpec.swift in Sources */,
 				983DFED11CDB423800D39731 /* Storyboard+SwizzlingSpec.swift in Sources */,
-				983DFF091CDB433A00D39731 /* FoodType.swift in Sources */,
+				983DFF091CDB433A00D39731 /* Food.swift in Sources */,
 				983DFECE1CDB423800D39731 /* NSWindowController+SwinjectSpec.swift in Sources */,
 				983DFEE11CDB425600D39731 /* AnimalPlayerViewController.swift in Sources */,
 				985315621CDB2DDE009E9FB7 /* SwinjectStoryboardTests.swift in Sources */,
-				983DFF061CDB433A00D39731 /* AnimalType.swift in Sources */,
+				983DFF061CDB433A00D39731 /* Animal.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Animal.swift
+++ b/Tests/Animal.swift
@@ -1,5 +1,5 @@
 //
-//  AnimalType.swift
+//  Animal.swift
 //  Swinject
 //
 //  Created by Yoichi Tagaya on 7/27/15.
@@ -8,14 +8,14 @@
 
 import Foundation
 
-internal protocol AnimalType {
+internal protocol Animal {
     var name: String? { get set }
 }
 
-internal class Cat: AnimalType {
+internal class Cat: Animal {
     var name: String?
     var sleeping = false
-    var favoriteFood: FoodType?
+    var favoriteFood: Food?
     
     init() {
     }
@@ -33,7 +33,7 @@ internal class Cat: AnimalType {
 internal class Siamese: Cat {
 }
 
-internal class Dog: AnimalType {
+internal class Dog: Animal {
     var name: String?
     
     init() {
@@ -44,6 +44,6 @@ internal class Dog: AnimalType {
     }
 }
 
-internal struct Turtle: AnimalType {
+internal struct Turtle: Animal {
     var name: String?
 }

--- a/Tests/Food.swift
+++ b/Tests/Food.swift
@@ -1,5 +1,5 @@
 //
-//  FoodType.swift
+//  Food.swift
 //  Swinject
 //
 //  Created by Yoichi Tagaya on 7/29/15.
@@ -8,6 +8,6 @@
 
 import Foundation
 
-internal protocol FoodType { }
+internal protocol Food { }
 
-internal class Sushi: FoodType { }
+internal class Sushi: Food { }

--- a/Tests/OSX/AnimalViewController.swift
+++ b/Tests/OSX/AnimalViewController.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 internal class AnimalViewController: NSViewController {
-    internal var animal: AnimalType?
+    internal var animal: Animal?
     
     internal required init?(coder: NSCoder) {
         super.init(coder: coder)

--- a/Tests/OSX/AnimalWindowController.swift
+++ b/Tests/OSX/AnimalWindowController.swift
@@ -9,7 +9,7 @@
 import AppKit
 
 internal class AnimalWindowController: NSWindowController {
-    internal var animal: AnimalType?
+    internal var animal: Animal?
     
     internal required init?(coder: NSCoder) {
         super.init(coder: coder)

--- a/Tests/OSX/SwinjectStoryboardSpec.swift
+++ b/Tests/OSX/SwinjectStoryboardSpec.swift
@@ -29,9 +29,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("Instantiation from storyboard") {
             it("injects view controller dependency definded by initCompleted handler.") {
                 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                container.register(Animal.self) { _ in Cat(name: "Mimi") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: container)
                 let animalViewController = storyboard.instantiateController(withIdentifier: "AnimalView") as! AnimalViewController
@@ -39,9 +39,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             }
             it("injects window controller dependency definded by initCompleted handler.") {
                 container.storyboardInitCompleted(AnimalWindowController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mew") }
+                container.register(Animal.self) { _ in Cat(name: "Mew") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: container)
                 let animalViewController = storyboard.instantiateController(withIdentifier: "AnimalWindow") as! AnimalWindowController
@@ -49,9 +49,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             }
             it("injects dependency to child view controllers.") {
                 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat() }
+                container.register(Animal.self) { _ in Cat() }
                     .inObjectScope(.container)
                 
                 let storyboard = SwinjectStoryboard.create(name: "Tabs", bundle: bundle, container: container)
@@ -66,9 +66,9 @@ class SwinjectStoryboardSpec: QuickSpec {
                 it("injects view controller dependency definded by initCompleted handler with the registration name.") {
                     // The registration name "hachi" is set in the storyboard.
                     container.storyboardInitCompleted(AnimalViewController.self, name: "hachi") { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Dog(name: "Hachi") }
+                    container.register(Animal.self) { _ in Dog(name: "Hachi") }
                     
                     // This registration should not be resolved.
                     container.storyboardInitCompleted(AnimalViewController.self) { _, c in
@@ -82,9 +82,9 @@ class SwinjectStoryboardSpec: QuickSpec {
                 it("injects window controller dependency definded by initCompleted handler with the registration name.") {
                     // The registration name "hachi" is set in the storyboard.
                     container.storyboardInitCompleted(AnimalWindowController.self, name: "pochi") { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Dog(name: "Pochi") }
+                    container.register(Animal.self) { _ in Dog(name: "Pochi") }
                     
                     // This registration should not be resolved.
                     container.storyboardInitCompleted(AnimalWindowController.self) { _, c in
@@ -99,9 +99,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             context("with container hierarchy") {
                 it("injects view controller dependency definded in the parent container.") {
                     container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                    container.register(Animal.self) { _ in Cat(name: "Mimi") }
                     let childContainer = Container(parent: container)
                     
                     let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: childContainer)
@@ -112,9 +112,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             context("with second controller instantiation during instantiation of initial one") {
                 it("injects second controller.") {
                     container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                    container.register(Animal.self) { _ in Cat(name: "Mimi") }
 
                     let storyboard = SwinjectStoryboard.create(name: "Pages", bundle: bundle, container: container)
                     let pagesController = storyboard.instantiateInitialController() as! AnimalPagesViewController
@@ -125,9 +125,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("Initial controller") {
             it("injects dependency definded by initCompleted handler.") {
                 container.storyboardInitCompleted(AnimalWindowController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mew") }
+                container.register(Animal.self) { _ in Cat(name: "Mew") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: container)
                 let animalViewController = storyboard.instantiateInitialController() as! AnimalWindowController
@@ -150,9 +150,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("Storyboard reference") {
             it("inject dependency to the view controller in the referenced storyboard.") {
                 SwinjectStoryboard.defaultContainer.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                SwinjectStoryboard.defaultContainer.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                SwinjectStoryboard.defaultContainer.register(Animal.self) { _ in Cat(name: "Mimi") }
                 
                 let storyboard1 = SwinjectStoryboard.create(name: "Storyboard1", bundle: bundle)
                 let windowController = storyboard1.instantiateInitialController() as! NSWindowController
@@ -175,9 +175,9 @@ class SwinjectStoryboardSpec: QuickSpec {
                 context("not using default container") {
                     it("injects dependency to the view controller opened via segue") {
                         container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                            c.animal = r.resolve(AnimalType.self)
+                            c.animal = r.resolve(Animal.self)
                         }
-                        container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                        container.register(Animal.self) { _ in Cat(name: "Mimi") }
 
                         let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
                         let windowController = storyboard.instantiateInitialController() as! NSWindowController

--- a/Tests/iOS-tvOS/AnimalPlayerViewController.swift
+++ b/Tests/iOS-tvOS/AnimalPlayerViewController.swift
@@ -9,7 +9,7 @@
 import AVKit
 
 internal class AnimalPlayerViewController: AVPlayerViewController {
-    internal var animal: AnimalType?
+    internal var animal: Animal?
     
     internal required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)

--- a/Tests/iOS-tvOS/AnimalViewController.swift
+++ b/Tests/iOS-tvOS/AnimalViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 internal class AnimalViewController: UIViewController {
-    internal var animal: AnimalType?
+    internal var animal: Animal?
     
     internal required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)

--- a/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
+++ b/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
@@ -29,9 +29,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("Instantiation from storyboard") {
             it("injects dependency definded by initCompleted handler.") {
                 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                container.register(Animal.self) { _ in Cat(name: "Mimi") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: container)
                 let animalViewController = storyboard.instantiateViewController(withIdentifier: "AnimalAsCat") as! AnimalViewController
@@ -39,9 +39,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             }
             it("injects dependency to child view controllers.") {
                 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat() }
+                container.register(Animal.self) { _ in Cat() }
                     .inObjectScope(.container)
 
                 let storyboard = SwinjectStoryboard.create(name: "Tabs", bundle: bundle, container: container)
@@ -56,9 +56,9 @@ class SwinjectStoryboardSpec: QuickSpec {
                 it("injects dependency definded by initCompleted handler with the registration name.") {
                     // The registration name "hachi" is set in the storyboard.
                     container.storyboardInitCompleted(AnimalViewController.self, name: "hachi") { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Dog(name: "Hachi") }
+                    container.register(Animal.self) { _ in Dog(name: "Hachi") }
                     
                     // This registration should not be resolved.
                     container.storyboardInitCompleted(AnimalViewController.self) { _, c in
@@ -73,9 +73,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             context("with container hierarchy") {
                 it("injects view controller dependency definded in the parent container.") {
                     container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                    container.register(Animal.self) { _ in Cat(name: "Mimi") }
                     let childContainer = Container(parent: container)
                     
                     let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: childContainer)
@@ -86,9 +86,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             context("with second controller instantiation during instantiation of initial one") {
                 it("injects second controller.") {
                     container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                    container.register(Animal.self) { _ in Cat(name: "Mimi") }
 
                     let storyboard = SwinjectStoryboard.create(name: "Pages", bundle: bundle, container: container)
                     let pagesController = storyboard.instantiateInitialViewController() as! AnimalPagesViewController
@@ -99,9 +99,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("Initial view controller") {
             it("injects dependency definded by initCompleted handler.") {
                 container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                container.register(Animal.self) { _ in Cat(name: "Mimi") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "Animals", bundle: bundle, container: container)
                 let animalViewController = storyboard.instantiateInitialViewController() as! AnimalViewController
@@ -111,9 +111,9 @@ class SwinjectStoryboardSpec: QuickSpec {
         describe("AVPlayerViewController") { // Test for Issue #18
             it("is able to inject a subclass of AVPlayerViewController") {
                 container.storyboardInitCompleted(AnimalPlayerViewController.self) { r, c in
-                    c.animal = r.resolve(AnimalType.self)
+                    c.animal = r.resolve(Animal.self)
                 }
-                container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                container.register(Animal.self) { _ in Cat(name: "Mimi") }
                 
                 let storyboard = SwinjectStoryboard.create(name: "AnimalPlayerViewController", bundle: bundle, container: container)
                 let animalPlayerViewController = storyboard.instantiateInitialViewController() as! AnimalPlayerViewController
@@ -140,9 +140,9 @@ class SwinjectStoryboardSpec: QuickSpec {
             describe("Storyboard reference") {
                 it("inject dependency to the view controller in the referenced storyboard.") {
                     SwinjectStoryboard.defaultContainer.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                        c.animal = r.resolve(AnimalType.self)
+                        c.animal = r.resolve(Animal.self)
                     }
-                    SwinjectStoryboard.defaultContainer.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                    SwinjectStoryboard.defaultContainer.register(Animal.self) { _ in Cat(name: "Mimi") }
 
                     let storyboard1 = SwinjectStoryboard.create(name: "Storyboard1", bundle: bundle)
                     let navigationController = storyboard1.instantiateInitialViewController() as! UINavigationController
@@ -165,9 +165,9 @@ class SwinjectStoryboardSpec: QuickSpec {
                     context("not using defaultContainer") {
                         it("injects dependency to the view controller opened via segue") {
                             container.storyboardInitCompleted(AnimalViewController.self) { r, c in
-                                c.animal = r.resolve(AnimalType.self)
+                                c.animal = r.resolve(Animal.self)
                             }
-                            container.register(AnimalType.self) { _ in Cat(name: "Mimi") }
+                            container.register(Animal.self) { _ in Cat(name: "Mimi") }
 
                             let storyboard = SwinjectStoryboard.create(name: "RelationshipReference1", bundle: bundle, container: container)
                             let navigationController = storyboard.instantiateInitialViewController() as! UINavigationController


### PR DESCRIPTION
Renamed protocols like `FooType` to follow Swift 3 naming guidelines.