### PR TITLE
Use Swift 3.0.2 (Xcode 8.2) on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,18 +7,15 @@ env:
     - LC_CTYPE=en_US.UTF-8
     - LANG=en_US.UTF-8
     - PROJECT=SwinjectStoryboard.xcodeproj
-    - IOS_SDK=iphonesimulator10.0
-    - OSX_SDK=macosx10.12
-    - TVOS_SDK=appletvsimulator10.0
   matrix:
 ## The iOS 8.1 simulator is commented out because it does not start. It looks a problem of the simulator.
 ## Uncomment the following line after the simulator problem is fixed.
 #    - DESTINATION="OS=8.1,name=iPhone 4S" SCHEME="Swinject-iOS" SDK="$IOS_SDK" PLATFORM="iOS" POD_LINT="NO" ACTION="test"
-    - DESTINATION="OS=9.3,name=iPhone 6" SCHEME="Swinject-iOS" SDK="$IOS_SDK" PLATFORM="iOS" POD_LINT="NO" ACTION="test"
-    - DESTINATION="OS=10.0,name=iPhone 6S Plus" SCHEME="Swinject-iOS" SDK="$IOS_SDK" PLATFORM="iOS" POD_LINT="YES" ACTION="test"
-    - DESTINATION="arch=x86_64" SCHEME="Swinject-OSX" SDK="$OSX_SDK" PLATFORM="Mac" POD_LINT="NO" ACTION="test"
-    - DESTINATION="OS=9.2,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="$TVOS_SDK" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"
-    - DESTINATION="OS=10.0,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="$TVOS_SDK" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"
+    - DESTINATION="OS=9.3,name=iPhone 6" SCHEME="Swinject-iOS" SDK="iphonesimulator" PLATFORM="iOS" POD_LINT="NO" ACTION="test"
+    - DESTINATION="OS=10.0,name=iPhone 6S Plus" SCHEME="Swinject-iOS" SDK="iphonesimulator" PLATFORM="iOS" POD_LINT="YES" ACTION="test"
+    - DESTINATION="arch=x86_64" SCHEME="Swinject-OSX" SDK="$OSX_SDK" PLATFORM="macosx" POD_LINT="NO" ACTION="test"
+    - DESTINATION="OS=9.2,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="appletvsimulator" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"
+    - DESTINATION="OS=10.0,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="appletvsimulator" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"
 before_install:
   - git submodule update --recursive
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 ## Uncomment the following line after the simulator problem is fixed.
 #    - DESTINATION="OS=8.1,name=iPhone 4S" SCHEME="Swinject-iOS" SDK="$IOS_SDK" PLATFORM="iOS" POD_LINT="NO" ACTION="test"
     - DESTINATION="OS=9.3,name=iPhone 6" SCHEME="Swinject-iOS" SDK="iphonesimulator" PLATFORM="iOS" POD_LINT="NO" ACTION="test"
-    - DESTINATION="OS=10.0,name=iPhone 6S Plus" SCHEME="Swinject-iOS" SDK="iphonesimulator" PLATFORM="iOS" POD_LINT="YES" ACTION="test"
+    - DESTINATION="OS=10.1,name=iPhone 6S Plus" SCHEME="Swinject-iOS" SDK="iphonesimulator" PLATFORM="iOS" POD_LINT="YES" ACTION="test"
     - DESTINATION="arch=x86_64" SCHEME="Swinject-OSX" SDK="$OSX_SDK" PLATFORM="macosx" POD_LINT="NO" ACTION="test"
     - DESTINATION="OS=9.2,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="appletvsimulator" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"
     - DESTINATION="OS=10.0,name=Apple TV 1080p" SCHEME="Swinject-tvOS" SDK="appletvsimulator" PLATFORM="tvOS" POD_LINT="NO" ACTION="test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # reference: http://www.objc.io/issue-6/travis-ci.html
 
 language: objective-c
-osx_image: xcode8
+osx_image: xcode8.2
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ script:
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" 
     -configuration Release ENABLE_TESTABILITY=YES ONLY_ACTIVE_ARCH=NO $ACTION | xcpretty
   - if [ $POD_LINT == "YES" ]; then
-      pod lib lint --quick;
+      pod repo update;
+      pod lib lint;
     fi
 notifications:
   email:


### PR DESCRIPTION
In .travis.yml:
- Updated the Swift (Xcode) version.
- Fixed failure of `pod lib lint`.
- Simplified SDK settings.