### PR TITLE
Update Cartfile for compatible matching instead of exact

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.0.0"
+github "Swinject/Swinject" ~> 2.0.0


### PR DESCRIPTION
Update Swinject dependency in cartfile to use a compatible match instead of an exact one.

Is there any reason not to make this change?