### PR TITLE
Remove leftover config submodule in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "Configurations"]
-  path = Configurations
-  url = https://github.com/jspahrsummers/xcconfigs
+


### PR DESCRIPTION
This is an artifact leftover from when the configs were added as a
submodule. The submodule was removed, but this entry in .gitmodules
remained.