### PR TITLE
Silence output of pod repo update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" 
     -configuration Release ENABLE_TESTABILITY=YES ONLY_ACTIVE_ARCH=NO $ACTION | xcpretty
   - if [ $POD_LINT == "YES" ]; then
-      pod repo update;
+      pod repo update --silent;
       pod lib lint;
     fi
 notifications:


### PR DESCRIPTION
This step was causing travis to terminate jobs due to log being too big