### PR TITLE
Add @objc annotation for the setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If you implicitly instantiate `UIWindow` and its root view controller from "Main
 
 ```swift
 extension SwinjectStoryboard {
-    class func setup() {
+    @objc class func setup() {
         defaultContainer.storyboardInitCompleted(AnimalViewController.self) { r, c in
             c.animal = r.resolve(Animal.self)
         }

--- a/Sources/SwinjectStoryboardProtocol.swift
+++ b/Sources/SwinjectStoryboardProtocol.swift
@@ -21,7 +21,7 @@ public protocol SwinjectStoryboardProtocol {
     ///
     /// ```swift
     /// extension SwinjectStoryboard {
-    ///     class func setup() {
+    ///     @objc class func setup() {
     ///         let container = defaultContainer
     ///         container.register(SomeType.self) {
     ///             _ in


### PR DESCRIPTION
This annotation is required for Swift 4 and isn't picked up as part of the migration.