### PR TITLE
KVC complaint Swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # reference: http://www.objc.io/issue-6/travis-ci.html
 
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.0
 env:
   global:
     - LC_CTYPE=en_US.UTF-8

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.0
-github "Quick/Nimble" ~> 6.0
+github "Quick/Quick" ~> 1.1
+github "Quick/Nimble" ~> 7.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v6.1.0"
+github "Quick/Nimble" "v7.0.1"
 github "Quick/Quick" "v1.1.0"
 github "Swinject/Swinject" "2.1.1"

--- a/Sources/InjectionVerifiable.swift
+++ b/Sources/InjectionVerifiable.swift
@@ -6,6 +6,6 @@
 //  Copyright © 2016 Swinject Contributors. All rights reserved.
 //
 
-internal protocol InjectionVerifiable: AnyObject {
+@objc internal protocol InjectionVerifiable: AnyObject {
     var wasInjected: Bool { get set }
 }

--- a/Sources/RegistrationNameAssociatable.swift
+++ b/Sources/RegistrationNameAssociatable.swift
@@ -6,6 +6,6 @@
 //  Copyright © 2015 Swinject Contributors. All rights reserved.
 //
 
-internal protocol RegistrationNameAssociatable: AnyObject {
+@objc internal protocol RegistrationNameAssociatable: AnyObject {
     var swinjectRegistrationName: String? { get set }
 }

--- a/Sources/ViewController+Swinject.swift
+++ b/Sources/ViewController+Swinject.swift
@@ -14,7 +14,7 @@ private var uivcRegistrationNameKey: String = "UIViewController.swinjectRegistra
 private var uivcWasInjectedKey: String = "UIViewController.wasInjected"
 
 extension UIViewController: RegistrationNameAssociatable, InjectionVerifiable {
-    @objc internal var swinjectRegistrationName: String? {
+    internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &uivcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &uivcRegistrationNameKey) }
     }
@@ -33,7 +33,7 @@ private var nsvcWasInjectedKey: String = "NSViewController.wasInjected"
 private var nswcWasInjectedKey: String = "NSWindowController.wasInjected"
 
 extension NSViewController: RegistrationNameAssociatable, InjectionVerifiable {
-    @objc internal var swinjectRegistrationName: String? {
+    internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &nsvcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &nsvcRegistrationNameKey) }
     }
@@ -45,7 +45,7 @@ extension NSViewController: RegistrationNameAssociatable, InjectionVerifiable {
 }
 
 extension NSWindowController: RegistrationNameAssociatable, InjectionVerifiable {
-    @objc internal var swinjectRegistrationName: String? {
+    internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &nsvcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &nsvcRegistrationNameKey) }
     }

--- a/Sources/ViewController+Swinject.swift
+++ b/Sources/ViewController+Swinject.swift
@@ -14,7 +14,7 @@ private var uivcRegistrationNameKey: String = "UIViewController.swinjectRegistra
 private var uivcWasInjectedKey: String = "UIViewController.wasInjected"
 
 extension UIViewController: RegistrationNameAssociatable, InjectionVerifiable {
-    internal var swinjectRegistrationName: String? {
+    @objc internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &uivcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &uivcRegistrationNameKey) }
     }
@@ -33,7 +33,7 @@ private var nsvcWasInjectedKey: String = "NSViewController.wasInjected"
 private var nswcWasInjectedKey: String = "NSWindowController.wasInjected"
 
 extension NSViewController: RegistrationNameAssociatable, InjectionVerifiable {
-    internal var swinjectRegistrationName: String? {
+    @objc internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &nsvcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &nsvcRegistrationNameKey) }
     }
@@ -45,7 +45,7 @@ extension NSViewController: RegistrationNameAssociatable, InjectionVerifiable {
 }
 
 extension NSWindowController: RegistrationNameAssociatable, InjectionVerifiable {
-    internal var swinjectRegistrationName: String? {
+    @objc internal var swinjectRegistrationName: String? {
         get { return getAssociatedString(key: &nsvcRegistrationNameKey) }
         set { setAssociatedString(newValue, key: &nsvcRegistrationNameKey) }
     }


### PR DESCRIPTION
Add @objc attribute to make sure the ViewControllers are KVC complaint for 'swinjectRegistrationName' in Swift 4.0