### PR TITLE
Points to other PR in Swinject for Container Protocol

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" ~> 2.4
+github "doozMen/Swinject" ~> 2.4.1

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "doozMen/Swinject" ~> 2.4.1
+github "doozMen/Swinject" ~> 2.4.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v7.0.3"
-github "Quick/Quick" "v1.2.0"
-github "Swinject/Swinject" "2.4.0"
+github "Quick/Nimble" "v7.1.1"
+github "Quick/Quick" "v1.3.0"
+github "doozMen/Swinject" "2.4.1"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ SwinjectStoryboard
 [![Swift Version](https://img.shields.io/badge/Swift-3-F16D39.svg?style=flat)](https://developer.apple.com/swift)
 
 SwinjectStoryboard is an extension of Swinject to automatically inject dependency to view controllers instantiated by a storyboard.
+## Dependencies
+Dependencies ar in Cartfile.
+
+Perform `carthage update` before building.
+
+**!!This specified verion points to doozMen/Swinject in Cartfile. Change this back to Swinject/Swinject when pr approved**
 
 ## Requirements
 

--- a/Sources/Container+SwinjectStoryboard.swift
+++ b/Sources/Container+SwinjectStoryboard.swift
@@ -9,7 +9,7 @@
 import Swinject
 
 #if os(iOS) || os(OSX) || os(tvOS)
-extension Container {
+extension ContainerProtocol {
     /// Adds a registration of the specified view or window controller that is configured in a storyboard.
     ///
     /// - Note: Do NOT explicitly resolve the controller registered by this method.
@@ -35,7 +35,7 @@ extension Container {
 #endif
 
 
-extension Container {
+extension ContainerProtocol {
 #if os(iOS) || os(tvOS)
     /// The typealias to UIViewController.
     public typealias Controller = UIViewController

--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -28,7 +28,7 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardProt
     /// Typical usecases of this property are:
     /// - Implicit instantiation of UIWindow and its root view controller from "Main" storyboard.
     /// - Storyboard references to transit from a storyboard to another.
-    public static var defaultContainer = Container()
+    public static var defaultContainer: ContainerProtocol = Container()
     
     // Boxing to workaround a runtime error [Xcode 7.1.1 and Xcode 7.2 beta 4]
     // If container property is Resolver type and a Resolver instance is assigned to the property,

--- a/SwinjectStoryboard.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwinjectStoryboard.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Swift is a protocol based language. In one project I faced the problem that it was difficult to write tests with a real container. I wanted to mock it out but because it was not a protocol this was difficult. I had to make some functions and types public as a downside of this approach. What do you think?