### PR TITLE
Updated iOS framework to Swift 4.2

### DIFF
--- a/Sources/SwinjectStoryboard.swift
+++ b/Sources/SwinjectStoryboard.swift
@@ -110,9 +110,15 @@ public class SwinjectStoryboard: _SwinjectStoryboardBase, SwinjectStoryboardProt
             fatalError("A type conforming Resolver protocol must conform _Resolver protocol too.")
         }
 
-        for child in viewController.childViewControllers {
-            injectDependency(to: child)
-        }
+        #if swift(>=4.2)
+            for child in viewController.children {
+                injectDependency(to: child)
+            }
+        #else
+            for child in viewController.childViewControllers {
+                injectDependency(to: child)
+            }
+        #endif
     }
     
 #elseif os(OSX)

--- a/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
+++ b/Tests/iOS-tvOS/SwinjectStoryboardSpec.swift
@@ -46,8 +46,15 @@ class SwinjectStoryboardSpec: QuickSpec {
 
                 let storyboard = SwinjectStoryboard.create(name: "Tabs", bundle: bundle, container: container)
                 let tabBarController = storyboard.instantiateViewController(withIdentifier: "TabBarController")
-                let animalViewController1 = tabBarController.childViewControllers[0] as! AnimalViewController
-                let animalViewController2 = tabBarController.childViewControllers[1] as! AnimalViewController
+                
+                #if swift(>=4.2)
+                    let animalViewController1 = tabBarController.children[0] as! AnimalViewController
+                    let animalViewController2 = tabBarController.children[1] as! AnimalViewController
+                #else
+                    let animalViewController1 = tabBarController.childViewControllers[0] as! AnimalViewController
+                    let animalViewController2 = tabBarController.childViewControllers[1] as! AnimalViewController
+                #endif
+                
                 let cat1 = animalViewController1.animal as! Cat
                 let cat2 = animalViewController2.animal as! Cat
                 expect(cat1 === cat2).to(beTrue()) // Workaround for crash in Nimble.


### PR DESCRIPTION
When you upgrade to Swift 4.2, the `childViewControllers` has renamed to `children` in iOS