### PR TITLE
fix load call not being allowed in a Swift class

### DIFF
--- a/Sources/SwinjectStoryboard+SetUp.m
+++ b/Sources/SwinjectStoryboard+SetUp.m
@@ -21,14 +21,11 @@
 
 @implementation SwinjectStoryboard (SetUp)
 
-+ (void)load {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        if ([self conformsToProtocol:@protocol(SwinjectStoryboardProtocol)] &&
-            [[self class] respondsToSelector:@selector(setup)]) {
-            [[self class] performSelector:@selector(setup)];
-        }
-    });
-}
-
 @end
+
+__attribute__((constructor)) static void swinjectStoryboardSetupEntry(void) {
+    if ([SwinjectStoryboard conformsToProtocol:@protocol(SwinjectStoryboardProtocol)] &&
+        [SwinjectStoryboard respondsToSelector:@selector(setup)]) {
+        [SwinjectStoryboard performSelector:@selector(setup)];
+    }
+}


### PR DESCRIPTION
In Xcode 10.2 with swift 5, there is an interesting error in my project giving the following on app launch:
`Swift class extensions and categories on Swift classes are not allowed to have +load methods`. It seems this objective-c category was added in here because the ability to call load in swift was removed in swift 1.2. This is a crafty way to get this to work but it seems that the stable ABI kills this hack.

the `__attribute__((constructor))` will give similar behavior to `load` but I think this gets around the point you wanted here, it seems `setup` is not used in the `SwinjectStoryboard` base class but I guess you want this available for subclassing? So in that case this doesn't solve that problem. A better solution would be to use an optional protocol to call setup in the init method, which would be safer

source here: https://stackoverflow.com/questions/2053029/how-exactly-does-attribute-constructor-work