### PR TITLE
Update to Swinject 2.7.x

### DIFF
--- a/Sources/SwinjectStoryboardOption.swift
+++ b/Sources/SwinjectStoryboardOption.swift
@@ -25,10 +25,6 @@ internal struct SwinjectStoryboardOption: ServiceKeyOption {
         return self.controllerType == another.controllerType
     }
     
-    internal var hashValue: Int {
-        return controllerType.hashValue
-    }
-    
     internal var description: String {
         return "Storyboard: \(controllerType)"
     }


### PR DESCRIPTION
On a clean project, Carthage would fail to build SwinjectStoryboard because it would resolve to Swinject 2.7.1, which contains a protocol change in ServiceKeyOption in comparison to 2.6.
The demo project from the repo on the other hand gets built because Carthage.resolved pointed to Swinject 2.6