### PR TITLE
Injected property wrapper for better usage

### DIFF
--- a/Sources/Injected.swift
+++ b/Sources/Injected.swift
@@ -1,0 +1,55 @@
+//
+//  Injected.swift
+//  SwinjectStoryboard
+//
+//  Created by Alex Frankiv on 17.01.2020.
+//  Copyright © 2020 Swinject Contributors. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS) || os(OSX)
+
+import Swinject
+
+/// Used for better and more obvious injection since swift 5.1
+@propertyWrapper
+public struct Injected<T> {
+
+    private let container: Container
+    private let name: String?
+    private var _wrappedValue: T?
+
+    public var wrappedValue: T? {
+        mutating get {
+            if self._wrappedValue == nil {
+                self._wrappedValue = self.container.resolve(T.self, name: self.name)
+            }
+            return self._wrappedValue
+        }
+    }
+
+    public init(initialValue value: T?, container: Container, name: String) {
+        self._wrappedValue = value
+        self.container = container
+        self.name = name
+    }
+
+    public init(initialValue value: T?, _ container: Container) {
+        self._wrappedValue = value
+        self.container = container
+        self.name = nil
+    }
+
+    public init(initialValue value: T?, _ name: String) {
+        self._wrappedValue = value
+		self.container = SwinjectStoryboard.defaultContainer
+		self.name = name
+    }
+
+    public init(wrappedValue value: T?) {
+        self._wrappedValue = value
+        self.container = SwinjectStoryboard.defaultContainer
+        self.name = nil
+    }
+}
+
+#endif

--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -121,6 +121,12 @@
 		CDA864B91EA9F2A600293FEC /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDA864B41EA9F29E00293FEC /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDA864BA1EA9F2A600293FEC /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDA864B51EA9F29E00293FEC /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CDA864BB1EA9F2AA00293FEC /* Swinject.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = CDA864961EA9F1A000293FEC /* Swinject.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FA0BD9DF23D210B80027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
+		FA0BD9E123D210B80027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
+		FA0BD9E323D210B80027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
+		FA0BD9E623D2114C0027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
+		FA0BD9E723D2114C0027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
+		FA0BD9E823D2114D0027FE2E /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0BD9DE23D210B80027FE2E /* Injected.swift */; };
 		FF492DA61EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */ = {isa = PBXBuildFile; fileRef = FF492DA21EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m */; };
 		FF492DA71EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */ = {isa = PBXBuildFile; fileRef = FF492DA21EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m */; };
 		FF492DA81EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */ = {isa = PBXBuildFile; fileRef = FF492DA21EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m */; };
@@ -290,6 +296,7 @@
 		CDA864B11EA9F28E00293FEC /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		CDA864B41EA9F29E00293FEC /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		CDA864B51EA9F29E00293FEC /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
+		FA0BD9DE23D210B80027FE2E /* Injected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injected.swift; sourceTree = "<group>"; };
 		FF492DA21EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SwinjectStoryboard+SetUp.m"; sourceTree = "<group>"; };
 		FF492DAF1EDA65D90081A4A7 /* NSStoryboard+Swizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSStoryboard+Swizzling.h"; sourceTree = "<group>"; };
 		FF492DB01EDA65D90081A4A7 /* NSStoryboard+Swizzling.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSStoryboard+Swizzling.m"; sourceTree = "<group>"; };
@@ -463,6 +470,7 @@
 				983DFEA11CDB410D00D39731 /* SwinjectStoryboard.swift */,
 				FF492DA21EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m */,
 				983DFEA41CDB410D00D39731 /* ViewController+Swinject.swift */,
+				FA0BD9DE23D210B80027FE2E /* Injected.swift */,
 				983DFF0A1CDB440800D39731 /* Box.swift */,
 				CD3AB1B11DC3A94A001A45FA /* InjectionVerifiable.swift */,
 				983DFF0E1CDB444E00D39731 /* RegistrationNameAssociatable.swift */,
@@ -923,6 +931,7 @@
 				FF492DA61EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */,
 				CD3AB1B21DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
 				98978E681DFC354B0046B966 /* UnavailableItems.swift in Sources */,
+				FA0BD9DF23D210B80027FE2E /* Injected.swift in Sources */,
 				983DFEAE1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF0F1CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAB1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
@@ -949,6 +958,7 @@
 				983DFEE01CDB425600D39731 /* AnimalPlayerViewController.swift in Sources */,
 				985904161CDB0AA700275E4A /* SwinjectStoryboardTests.swift in Sources */,
 				983DFF041CDB433A00D39731 /* Animal.swift in Sources */,
+				FA0BD9E623D2114C0027FE2E /* Injected.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -960,6 +970,7 @@
 				FF492DA71EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */,
 				CD3AB1B31DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
 				98978E691DFC354B0046B966 /* UnavailableItems.swift in Sources */,
+				FA0BD9E123D210B80027FE2E /* Injected.swift in Sources */,
 				983DFEAF1CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				FF492DB21EDA65D90081A4A7 /* NSStoryboard+Swizzling.m in Sources */,
 				983DFF101CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
@@ -979,6 +990,7 @@
 				983DFED31CDB423800D39731 /* ViewController+SwinjectSpec.swift in Sources */,
 				983DFECA1CDB423800D39731 /* Container+SwinjectStoryboardSpec.swift in Sources */,
 				983DFF051CDB433A00D39731 /* Animal.swift in Sources */,
+				FA0BD9E723D2114C0027FE2E /* Injected.swift in Sources */,
 				983DFF081CDB433A00D39731 /* Food.swift in Sources */,
 				983DFEFC1CDB426100D39731 /* SwinjectStoryboardSpec.swift in Sources */,
 				983DFED01CDB423800D39731 /* Storyboard+SwizzlingSpec.swift in Sources */,
@@ -998,6 +1010,7 @@
 				FF492DA81EDA490F0081A4A7 /* SwinjectStoryboard+SetUp.m in Sources */,
 				CD3AB1B41DC3A94A001A45FA /* InjectionVerifiable.swift in Sources */,
 				98978E6A1DFC354B0046B966 /* UnavailableItems.swift in Sources */,
+				FA0BD9E323D210B80027FE2E /* Injected.swift in Sources */,
 				983DFEB01CDB410D00D39731 /* SwinjectStoryboardOption.swift in Sources */,
 				983DFF111CDB444E00D39731 /* RegistrationNameAssociatable.swift in Sources */,
 				983DFEAD1CDB410D00D39731 /* SwinjectStoryboard.swift in Sources */,
@@ -1024,6 +1037,7 @@
 				983DFEE11CDB425600D39731 /* AnimalPlayerViewController.swift in Sources */,
 				985315621CDB2DDE009E9FB7 /* SwinjectStoryboardTests.swift in Sources */,
 				983DFF061CDB433A00D39731 /* Animal.swift in Sources */,
+				FA0BD9E823D2114D0027FE2E /* Injected.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I'd like to suggest a feature that I was lacking: property wrapper for the DI. Finally thanks to Swift 5 updates it was possible to implement.

Let me explain the problem it solves in a few words.
If we have `viewModel` injected in `UIViewController`, we usually want it to be private to provide some kind of encapsulation. 
```
class MyViewController: UIViewController {

private var viewModel: MyViewModel!

...
}
```
However, it's not possible to do that if we resolve it outside the `UIViewController` which is especially true if we use `SwinjectStoryboard` and resolve this value in the `storyboardInitCompleted`.

So we usually fall back to this:
```
var viewModel: MyViewModel!
```

With the use of my approach we can easily write:
```
@Injected private var viewModel: MyViewModel!
```
This gives  us the ability to preserve encapsulation, inject property without problems and keep our code clear and nice.

Moreover, we can specify the container for injection to be resolved from and/or name of the dependency.
```
@Injected(SwinjectStoryboard.defaultContainer, "myDependency") private var viewModel: MyViewModel!
```

I feel really bad about having to write so many `init`s instead of one but it's the only way to deal with this [swift bug](https://bugs.swift.org/browse/SR-11480)

I'm looking forward to see this in future releases!