### PR TITLE
Fix SwinjectStoryboardOption to conform ServiceKeyOption

### DIFF
--- a/Sources/SwinjectStoryboardOption.swift
+++ b/Sources/SwinjectStoryboardOption.swift
@@ -25,8 +25,8 @@ internal struct SwinjectStoryboardOption: ServiceKeyOption {
         return self.controllerType == another.controllerType
     }
     
-    internal var hashValue: Int {
-        return controllerType.hashValue
+    internal func hash(into: inout Hasher) {
+        controllerType.hash(into: &into)
     }
     
     internal var description: String {


### PR DESCRIPTION
## Description

I noticed this issue because Carthage build was failing due to a compilation error in `SwinjectStoryboardOption`
```
internal struct SwinjectStoryboardOption: ServiceKeyOption {
                ^
Swinject.ServiceKeyOption:3:10: note: protocol requires function 'hash(into:)' with type '(inout Hasher) -> ()'
    func hash(into: inout Hasher)
         ^

** ARCHIVE FAILED **
```

I checked that it can be compiled without problems if it conforms to `ServiceKeyOption` protocol. I would appreciate your feedback🙏