### PR TITLE
Fix the macOS deployment target for macOS unit test target

### DIFF
--- a/SwinjectStoryboard.xcodeproj/project.pbxproj
+++ b/SwinjectStoryboard.xcodeproj/project.pbxproj
@@ -1164,6 +1164,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};
@@ -1178,6 +1179,7 @@
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.el-eleven.SwinjectStoryboardTests";
 				PRODUCT_NAME = "$(PROJECT_NAME)Tests";
 			};


### PR DESCRIPTION
PR #159 unexpectedly set `MACOSX_DEPLOYMENT_TARGET` from 10.11 to 10.10 for macOS unit test target although 10.11 is required to test storyboard references.

- https://github.com/Swinject/SwinjectStoryboard/pull/159/files#diff-527b6a0a8964115dbe03bdf6a3a3527177e5843de7809349e6cb1e11255e3de7L1211
- https://github.com/Swinject/SwinjectStoryboard/pull/159/files#diff-527b6a0a8964115dbe03bdf6a3a3527177e5843de7809349e6cb1e11255e3de7L1226

In this PR, the macOS target version for the test target is reverted to 10.11.
