### PR TITLE
Fix Makefile to get git version tag properly in one more command.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ push-to-upstream:
 #
 # Make a release for Carthage.
 #
-VERSION_TAG=$(shell git describe --abbrev=0)
+VERSION_TAG=$(shell git describe --tags --abbrev=0)
 .PHONY: carthage-release
 carthage-release:
 ifeq ($(shell which gh),)


### PR DESCRIPTION
I noticed PR #163 was insufficient to fix our Makefile.

In this PR, I added `--tags` option to one more `git describe` command.