### PR TITLE
Remove minor version lock (Cocoapods)

### DIFF
--- a/SwinjectStoryboard.podspec
+++ b/SwinjectStoryboard.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
-  s.dependency 'Swinject', '~> 2.7.1'
+  s.dependency 'Swinject', '~> 2.7'
   s.requires_arc = true
 end


### PR DESCRIPTION
The problem is that we can't use the newer version of Swinject for CocoaPods only.
I just removed this lock.