### PR TITLE
chore: fix updated pod config

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" ~> 2.7.1
+github "Swinject/Swinject" ~> 2.9.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Swinject/Swinject" "2.7.1"
+github "Swinject/Swinject" "2.9.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Swinject/Swinject.git",
         "state": {
           "branch": null,
-          "revision": "8a76d2c74bafbb455763487cc6a08e91bad1f78b",
-          "version": "2.7.1"
+          "revision": "be9dbcc7b86811bc131539a20c6f9c2d3e56919f",
+          "version": "2.9.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@ import PackageDescription
 let package = Package(
     name: "SwinjectStoryboard",
     platforms: [
-        .macOS(.v10_10),
-        .iOS(.v9),
-        .tvOS(.v9),
+        .macOS(.v10_13),
+        .iOS(.v12),
+        .tvOS(.v12),
     ],
     products: [
         .library(name: "SwinjectStoryboard", targets: ["SwinjectStoryboard"]),

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SwinjectStoryboard is an extension of Swinject to automatically inject dependenc
 
 ## Requirements
 
-- iOS 8.0+ / Mac OS X 10.10+ / tvOS 9.0+
+- iOS 12.0+ / Mac OS X 10.13+ / tvOS 12.0+
 - Xcode 8+
 
 ## Installation

--- a/Sources/ViewController+Swinject.swift
+++ b/Sources/ViewController+Swinject.swift
@@ -61,19 +61,19 @@ extension NSWindowController: RegistrationNameAssociatable, InjectionVerifiable 
 #endif
 
 extension NSObject {
-    fileprivate func getAssociatedString(key: UnsafeRawPointer) -> String? {
+    fileprivate func getAssociatedString(key: UnsafePointer<String>) -> String? {
         return objc_getAssociatedObject(self, key) as? String
     }
 
-    fileprivate func setAssociatedString(_ string: String?, key: UnsafeRawPointer) {
+    fileprivate func setAssociatedString(_ string: String?, key: UnsafePointer<String>) {
         objc_setAssociatedObject(self, key, string, objc_AssociationPolicy.OBJC_ASSOCIATION_COPY)
     }
 
-    fileprivate func getAssociatedBool(key: UnsafeRawPointer) -> Bool? {
+    fileprivate func getAssociatedBool(key: UnsafePointer<String>) -> Bool? {
         return (objc_getAssociatedObject(self, key) as? NSNumber)?.boolValue
     }
     
-    fileprivate func setAssociatedBool(_ bool: Bool, key: UnsafeRawPointer) {
+    fileprivate func setAssociatedBool(_ bool: Bool, key: UnsafePointer<String>) {
         objc_setAssociatedObject(self, key, NSNumber(value: bool), objc_AssociationPolicy.OBJC_ASSOCIATION_COPY)
     }
 }

--- a/SwinjectStoryboard.podspec
+++ b/SwinjectStoryboard.podspec
@@ -16,9 +16,9 @@ Pod::Spec.new do |s|
   s.ios.source_files = core_files, objc_files, 'Sources/iOS-tvOS/*.{swift,h,m}'
   s.osx.source_files = core_files, objc_files, 'Sources/OSX/*.{swift,h,m}'
   s.tvos.source_files = core_files, objc_files, 'Sources/iOS-tvOS/*.{swift,h,m}'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.10'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '12.0'
   s.dependency 'Swinject', '~> 2.7'
   s.requires_arc = true
 end


### PR DESCRIPTION
Fixed warnings preventing pod lib lint to pass
Updated minimum platforms requirements to match in both Podspec and Package.swift, allowing compatibility with Swinject 2.9.1

This should hopefully fix #181, fix #169, fix #179 